### PR TITLE
Fix trailing slash on paths rule to allow single slash paths

### DIFF
--- a/specifications/openapi/sources/refining-rules/no-trailing-slash-on-paths/rules/no-trailing-slash-on-paths.openapi-v2-v3.spectral-v6.yaml
+++ b/specifications/openapi/sources/refining-rules/no-trailing-slash-on-paths/rules/no-trailing-slash-on-paths.openapi-v2-v3.spectral-v6.yaml
@@ -10,4 +10,4 @@ rules:
     then:
       function: pattern
       functionOptions:
-        notMatch: /$
+        notMatch: .+\/$

--- a/specifications/openapi/sources/refining-rules/no-trailing-slash-on-paths/tests/no-trailing-slash-on-paths.rule-test.yaml
+++ b/specifications/openapi/sources/refining-rules/no-trailing-slash-on-paths/tests/no-trailing-slash-on-paths.rule-test.yaml
@@ -46,3 +46,12 @@ rules:
             version: "1.0"
           paths:
             /a-path: {}
+      - description: must return no problem if path is a single slash
+        expected: []
+        documentTemplate:
+          openapi: "3.1.0"
+          info:
+            title: an api
+            version: "1.0"
+          paths:
+            /: {}


### PR DESCRIPTION
The trailing slash on paths rule doesn't take into account single slash paths ("/"). Since a single slash path is used to define the root path, this rule disallows that.

With this change, which is aligned with Spectral's default ruleset (see [path-keys-no-trailing-slash](https://github.com/stoplightio/spectral/blob/9b50f88d6a6760c2ec4a924441185078921a4582/packages/rulesets/src/oas/index.ts#L305)), you'll be able to define the single slash path ("/") without triggering a linter error.